### PR TITLE
Replace never_add.csv with RSS feed in index.json

### DIFF
--- a/index.json
+++ b/index.json
@@ -23,11 +23,10 @@
       "format": "Markdown — instructions for AI agents using this repo as a skill",
       "best_for": "AI agents needing guidance on how to fetch and present headlines"
     },
-    "never_add": {
-      "url": "https://raw.githubusercontent.com/joylarkin/openclaw-security-news/main/never_add.csv",
-      "columns": ["url"],
-      "format": "CSV — one URL per line of articles that must never be added to README or CSV",
-      "best_for": "automation: check every candidate URL against this list before adding; skip any match"
+    "rss": {
+      "url": "https://raw.githubusercontent.com/joylarkin/openclaw-security-news/main/feed.xml",
+      "format": "RSS 2.0 — standard feed with items sorted by date descending",
+      "best_for": "RSS readers, feed aggregators, and services that consume standard RSS"
     }
   },
   "automation_protocol": {


### PR DESCRIPTION
## Summary
Updated the index.json metadata to replace the `never_add` CSV resource with an RSS feed resource, shifting from a blocklist-based approach to a standard feed distribution format.

## Key Changes
- Removed `never_add` resource configuration that referenced a CSV blocklist of URLs to exclude
- Added `rss` resource configuration pointing to a standard RSS 2.0 feed (feed.xml)
- Updated resource metadata to reflect the new feed format and use cases (RSS readers, feed aggregators, and standard RSS consumers)

## Implementation Details
- The RSS feed is sorted by date in descending order
- The new resource maintains the same repository base URL structure
- This change suggests a shift in the automation protocol from exclusion-based filtering to standard feed consumption patterns

https://claude.ai/code/session_01NTPjWYKnmN8smxiW1JUicg