### PR TITLE
Add script to remove empty date headers from README

### DIFF
--- a/.github/workflows/generate-rss.yml
+++ b/.github/workflows/generate-rss.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Strip empty date headers from README
+        run: python scripts/strip_empty_dates.py
+
       - name: Generate RSS feed
         run: python scripts/generate_feed.py
 
@@ -28,9 +31,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add feed.xml
+          git add README.md feed.xml
           if git diff --staged --quiet; then
-            echo "No changes to feed.xml"
+            echo "No changes to commit"
           else
             git commit -m "chore: update RSS feed $(date -u '+%Y-%m-%d %H:%M UTC')"
             git push

--- a/README.md
+++ b/README.md
@@ -88,10 +88,6 @@ Updated regularly.
 - [TechRadar Pro - Shadow AI and agents like OpenClaw are hijacking corporate data too easily - April 27, 2026](https://www.techradar.com/pro/shadow-ai-and-agents-like-openclaw-are-hijacking-corporate-data-too-easily)
 - [CyberPress - Multiple OpenClaw Vulnerabilities Enable Policy Bypass and Host Override Attacks - April 27, 2026](https://cyberpress.org/multiple-openclaw-vulnerabilities/)
 
-### 2026-04-26
-
-### 2026-04-25
-
 ### 2026-04-24
 - [DigiTimes Asia - OpenClaw's growing pains: innovation outpaces enterprise security - April 24, 2026](https://www.digitimes.com/news/a20260423VL213/niche-security-software-tencent.html)
 
@@ -525,8 +521,6 @@ Updated regularly.
 - [The Decoder - OpenClaw (formerly Clawdbot) and Moltbook let attackers walk through the front door - February 1, 2026](https://the-decoder.com/openclaw-formerly-clawdbot-and-moltbook-let-attackers-walk-through-the-front-door/)
 - [Tom's Hardware - Malicious OpenClaw 'skill' targets crypto users on ClawHub — 14 malicious skills were uploaded to ClawHub last month - February 1, 2026](https://www.tomshardware.com/tech-industry/openai-hires-genius-openclaw-creator-but-popular-ai-assistant-will-remain-open-source-sam-altman-says-creator-will-work-on-smart-agents-in-new-role)
 
-### 2026-01-31
-
 ### 2026-01-30
 - [Angles of Attack: The AI Security Intelligence Brief - This Is Apparently The Stupidest Timeline, So I Guess We're Talking About Moltbook Now - February 1, 2026](https://disesdi.substack.com/p/this-is-apparently-the-stupidest)
 - [Dark Reading - OpenClaw AI Runs Wild in Business Environments - January 30, 2026](https://www.darkreading.com/application-security/openclaw-ai-runs-wild-business-environments)
@@ -537,8 +531,6 @@ Updated regularly.
 - [Gartner - OpenClaw (Formerly Moltbot, Clawdbot): Agentic Productivity Comes With Unacceptable Cybersecurity Risk - January 29, 2026](https://www.gartner.com/en/documents/7381830)
 - [Inc - OpenClaw Can Run Your Whole Computer—and That’s Exactly Why Security Experts Are Panicking - January 29, 2026](https://www.inc.com/ben-sherry/the-tech-world-loves-this-powerful-ai-agent-but-its-also-a-security-nightmare/91294337)
 - [IBM - OpenClaw, Moltbook and the future of AI agents - January 29, 2026](https://www.ibm.com/think/news/clawdbot-ai-agent-testing-limits-vertical-integration)
-
-### 2026-01-28
 
 ### 2026-01-27
 - [Mashable - Clawdbot AI security risks you need to know before trying it - January 27, 2026](https://mashable.com/article/clawdbot-ai-security-risks)

--- a/scripts/strip_empty_dates.py
+++ b/scripts/strip_empty_dates.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Remove empty date headers from the HEADLINES block in README.md.
+
+A date header is "empty" when it has no bullet-point entries before the next
+date header (or the HEADLINES_END marker).  Running this script is idempotent.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def strip_empty_dates(text: str) -> str:
+    """Return text with empty ### YYYY-MM-DD sections removed from HEADLINES block."""
+    start_marker = "<!-- HEADLINES_START -->"
+    end_marker = "<!-- HEADLINES_END -->"
+
+    start_idx = text.find(start_marker)
+    end_idx = text.find(end_marker)
+    if start_idx == -1 or end_idx == -1:
+        return text
+
+    before = text[: start_idx + len(start_marker)]
+    block = text[start_idx + len(start_marker) : end_idx]
+    after = text[end_idx:]
+
+    # Split into per-date sections; keep the leading content before the first header.
+    sections = re.split(r"(?=^### \d{4}-\d{2}-\d{2})", block, flags=re.MULTILINE)
+
+    kept = []
+    for section in sections:
+        header_m = re.match(r"^### \d{4}-\d{2}-\d{2}", section)
+        if not header_m:
+            # Content before the first date header — always keep.
+            kept.append(section)
+            continue
+        # Keep the section only if it contains at least one bullet entry.
+        if re.search(r"^- \[", section, re.MULTILINE):
+            kept.append(section)
+
+    return before + "".join(kept) + after
+
+
+def main():
+    original = README.read_text(encoding="utf-8")
+    cleaned = strip_empty_dates(original)
+    if cleaned == original:
+        print("No empty date headers found — nothing to do.")
+        return
+    removed = original.count("\n### ") - cleaned.count("\n### ")
+    README.write_text(cleaned, encoding="utf-8")
+    print(f"Removed {removed} empty date header(s) from {README.name}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
This PR adds automation to clean up empty date headers from the HEADLINES section of README.md and integrates it into the RSS feed generation workflow.

## Key Changes
- **New script**: `scripts/strip_empty_dates.py` - Removes date headers (### YYYY-MM-DD format) that have no bullet-point entries before the next date header or end marker
  - Operates only within the `<!-- HEADLINES_START -->` and `<!-- HEADLINES_END -->` markers
  - Idempotent operation (safe to run multiple times)
  - Preserves content before the first date header
  
- **Updated workflow**: `.github/workflows/generate-rss.yml` - Integrated the cleanup script into the RSS generation pipeline
  - Runs `strip_empty_dates.py` before generating the RSS feed
  - Updated git add command to include README.md alongside feed.xml
  - Updated commit message logic to reflect both potential changes

- **Cleaned README.md**: Removed 4 empty date headers (2026-04-26, 2026-04-25, 2026-01-31, 2026-01-28) that had no associated entries

## Implementation Details
The script uses regex pattern matching to:
- Split the HEADLINES block into per-date sections
- Identify date headers using the pattern `### YYYY-MM-DD`
- Detect bullet entries using the pattern `- [`
- Preserve all non-empty sections and content before the first header

https://claude.ai/code/session_0139ctu4xeddrPABw3pYbrJ1