### PR TITLE
Add git history fallback for evergreen link pubDates in RSS feed

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -5,7 +5,7 @@
     <link>https://github.com/joylarkin/openclaw-security-news</link>
     <description>Curated security news about OpenClaw vulnerabilities, exploits, and advisories. Updated twice daily.</description>
     <language>en-us</language>
-    <lastBuildDate>Sat, 04 Jul 2026 05:01:13 +0000</lastBuildDate>
+    <lastBuildDate>Sat, 04 Jul 2026 20:56:12 +0000</lastBuildDate>
     <atom:link href="https://raw.githubusercontent.com/joylarkin/openclaw-security-news/main/feed.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>PCQuest - OpenClaw skill store breach puts agent permissions under the microscope - July 2026</title>
@@ -201,6 +201,83 @@
       <link>https://www.backslash.security/blog/openclaw-security-risks-explained?utm_source=openclaw-security-news</link>
       <guid isPermaLink="true">https://www.backslash.security/blog/openclaw-security-risks-explained?utm_source=openclaw-security-news</guid>
       <pubDate>Thu, 04 Jun 2026 00:00:00 +0000</pubDate>
+      <category>Vendor Advisories</category>
+    </item>
+    <item>
+      <title>NVD National Vulnerability Database - Search for OpenClaw</title>
+      <link>https://nvd.nist.gov/vuln/search#/nvd/home?keyword=openclaw&amp;resultType=records?utm_source=openclaw-security-news</link>
+      <guid isPermaLink="true">https://nvd.nist.gov/vuln/search#/nvd/home?keyword=openclaw&amp;resultType=records?utm_source=openclaw-security-news</guid>
+      <pubDate>Wed, 03 Jun 2026 15:11:10 +0000</pubDate>
+      <category>Government Warnings</category>
+    </item>
+    <item>
+      <title>CERT BUND Germany - WID-SEC-2026-0424 OpenClaw: Mehrere Schwachstellen</title>
+      <link>https://wid.cert-bund.de/portal/wid/securityadvisory?name=WID-SEC-2026-0424?utm_source=openclaw-security-news</link>
+      <guid isPermaLink="true">https://wid.cert-bund.de/portal/wid/securityadvisory?name=WID-SEC-2026-0424?utm_source=openclaw-security-news</guid>
+      <pubDate>Wed, 03 Jun 2026 15:11:10 +0000</pubDate>
+      <category>Government Warnings</category>
+    </item>
+    <item>
+      <title>CERT BUND Germany - Search for OpenClaw Advisories</title>
+      <link>https://wid.cert-bund.de/portal/search-de/content?searchQuery=openclaw&amp;category=securityAdvisory&amp;moduleForNavigation=wid?utm_source=openclaw-security-news</link>
+      <guid isPermaLink="true">https://wid.cert-bund.de/portal/search-de/content?searchQuery=openclaw&amp;category=securityAdvisory&amp;moduleForNavigation=wid?utm_source=openclaw-security-news</guid>
+      <pubDate>Wed, 03 Jun 2026 15:11:10 +0000</pubDate>
+      <category>Government Warnings</category>
+    </item>
+    <item>
+      <title>Centre for Cybersecurity Belgium - Search for OpenClaw Advisories</title>
+      <link>https://ccb.belgium.be/search?utm_source=openclaw-security-news</link>
+      <guid isPermaLink="true">https://ccb.belgium.be/search?utm_source=openclaw-security-news</guid>
+      <pubDate>Wed, 03 Jun 2026 15:11:10 +0000</pubDate>
+      <category>Government Warnings</category>
+    </item>
+    <item>
+      <title>CERT CVE Croatia - Proizvođač: openclaw</title>
+      <link>https://cve.cert.hr/?vendor=openclaw?utm_source=openclaw-security-news</link>
+      <guid isPermaLink="true">https://cve.cert.hr/?vendor=openclaw?utm_source=openclaw-security-news</guid>
+      <pubDate>Wed, 03 Jun 2026 15:11:10 +0000</pubDate>
+      <category>Government Warnings</category>
+    </item>
+    <item>
+      <title>Days Since Last OpenClaw CVE Tracker</title>
+      <link>https://days-since-openclaw-cve.com?utm_source=openclaw-security-news</link>
+      <guid isPermaLink="true">https://days-since-openclaw-cve.com?utm_source=openclaw-security-news</guid>
+      <pubDate>Wed, 03 Jun 2026 15:11:10 +0000</pubDate>
+      <category>Observability</category>
+    </item>
+    <item>
+      <title>OpenClaw CVE &amp; Security Advisory Tracker</title>
+      <link>https://github.com/jgamblin/OpenClawCVEs?utm_source=openclaw-security-news</link>
+      <guid isPermaLink="true">https://github.com/jgamblin/OpenClawCVEs?utm_source=openclaw-security-news</guid>
+      <pubDate>Wed, 03 Jun 2026 15:11:10 +0000</pubDate>
+      <category>Observability</category>
+    </item>
+    <item>
+      <title>DECLAWED - A live threat intelligence dashboard built by SecurityScorecard's STRIKE Team providing visibility into the global exposure of OpenClaw AI agent control panels</title>
+      <link>https://declawed.io/?utm_source=openclaw-security-news</link>
+      <guid isPermaLink="true">https://declawed.io/?utm_source=openclaw-security-news</guid>
+      <pubDate>Wed, 03 Jun 2026 15:11:10 +0000</pubDate>
+      <category>Observability</category>
+    </item>
+    <item>
+      <title>AIPwn - OpenClaw Security Watchboard</title>
+      <link>https://aipwn.org/openclaw?utm_source=openclaw-security-news</link>
+      <guid isPermaLink="true">https://aipwn.org/openclaw?utm_source=openclaw-security-news</guid>
+      <pubDate>Wed, 03 Jun 2026 15:11:10 +0000</pubDate>
+      <category>Observability</category>
+    </item>
+    <item>
+      <title>OpenClaw Exposure Watchboard - This page lists publicly reachable active OpenClaw instances for defensive awareness</title>
+      <link>https://openclaw.allegro.earth/?utm_source=openclaw-security-news</link>
+      <guid isPermaLink="true">https://openclaw.allegro.earth/?utm_source=openclaw-security-news</guid>
+      <pubDate>Wed, 03 Jun 2026 15:11:10 +0000</pubDate>
+      <category>Observability</category>
+    </item>
+    <item>
+      <title>VulnCheck - Ongoing OpenClaw CVE Advisories</title>
+      <link>https://www.vulncheck.com/advisories?utm_source=openclaw-security-news</link>
+      <guid isPermaLink="true">https://www.vulncheck.com/advisories?utm_source=openclaw-security-news</guid>
+      <pubDate>Wed, 03 Jun 2026 15:11:10 +0000</pubDate>
       <category>Vendor Advisories</category>
     </item>
     <item>
@@ -3275,72 +3352,6 @@
       <guid isPermaLink="true">https://www.forrester.com/blogs/ready-for-openclaw-to-pry-into-your-environment-and-grip-your-data/?utm_source=openclaw-security-news</guid>
       <pubDate>Mon, 26 Jan 2026 00:00:00 +0000</pubDate>
       <category>OpenClaw Headlines</category>
-    </item>
-    <item>
-      <title>NVD National Vulnerability Database - Search for OpenClaw</title>
-      <link>https://nvd.nist.gov/vuln/search#/nvd/home?keyword=openclaw&amp;resultType=records?utm_source=openclaw-security-news</link>
-      <guid isPermaLink="true">https://nvd.nist.gov/vuln/search#/nvd/home?keyword=openclaw&amp;resultType=records?utm_source=openclaw-security-news</guid>
-      <category>Government Warnings</category>
-    </item>
-    <item>
-      <title>CERT BUND Germany - WID-SEC-2026-0424 OpenClaw: Mehrere Schwachstellen</title>
-      <link>https://wid.cert-bund.de/portal/wid/securityadvisory?name=WID-SEC-2026-0424?utm_source=openclaw-security-news</link>
-      <guid isPermaLink="true">https://wid.cert-bund.de/portal/wid/securityadvisory?name=WID-SEC-2026-0424?utm_source=openclaw-security-news</guid>
-      <category>Government Warnings</category>
-    </item>
-    <item>
-      <title>CERT BUND Germany - Search for OpenClaw Advisories</title>
-      <link>https://wid.cert-bund.de/portal/search-de/content?searchQuery=openclaw&amp;category=securityAdvisory&amp;moduleForNavigation=wid?utm_source=openclaw-security-news</link>
-      <guid isPermaLink="true">https://wid.cert-bund.de/portal/search-de/content?searchQuery=openclaw&amp;category=securityAdvisory&amp;moduleForNavigation=wid?utm_source=openclaw-security-news</guid>
-      <category>Government Warnings</category>
-    </item>
-    <item>
-      <title>Centre for Cybersecurity Belgium - Search for OpenClaw Advisories</title>
-      <link>https://ccb.belgium.be/search?utm_source=openclaw-security-news</link>
-      <guid isPermaLink="true">https://ccb.belgium.be/search?utm_source=openclaw-security-news</guid>
-      <category>Government Warnings</category>
-    </item>
-    <item>
-      <title>CERT CVE Croatia - Proizvođač: openclaw</title>
-      <link>https://cve.cert.hr/?vendor=openclaw?utm_source=openclaw-security-news</link>
-      <guid isPermaLink="true">https://cve.cert.hr/?vendor=openclaw?utm_source=openclaw-security-news</guid>
-      <category>Government Warnings</category>
-    </item>
-    <item>
-      <title>Days Since Last OpenClaw CVE Tracker</title>
-      <link>https://days-since-openclaw-cve.com?utm_source=openclaw-security-news</link>
-      <guid isPermaLink="true">https://days-since-openclaw-cve.com?utm_source=openclaw-security-news</guid>
-      <category>Observability</category>
-    </item>
-    <item>
-      <title>OpenClaw CVE &amp; Security Advisory Tracker</title>
-      <link>https://github.com/jgamblin/OpenClawCVEs?utm_source=openclaw-security-news</link>
-      <guid isPermaLink="true">https://github.com/jgamblin/OpenClawCVEs?utm_source=openclaw-security-news</guid>
-      <category>Observability</category>
-    </item>
-    <item>
-      <title>DECLAWED - A live threat intelligence dashboard built by SecurityScorecard's STRIKE Team providing visibility into the global exposure of OpenClaw AI agent control panels</title>
-      <link>https://declawed.io/?utm_source=openclaw-security-news</link>
-      <guid isPermaLink="true">https://declawed.io/?utm_source=openclaw-security-news</guid>
-      <category>Observability</category>
-    </item>
-    <item>
-      <title>AIPwn - OpenClaw Security Watchboard</title>
-      <link>https://aipwn.org/openclaw?utm_source=openclaw-security-news</link>
-      <guid isPermaLink="true">https://aipwn.org/openclaw?utm_source=openclaw-security-news</guid>
-      <category>Observability</category>
-    </item>
-    <item>
-      <title>OpenClaw Exposure Watchboard - This page lists publicly reachable active OpenClaw instances for defensive awareness</title>
-      <link>https://openclaw.allegro.earth/?utm_source=openclaw-security-news</link>
-      <guid isPermaLink="true">https://openclaw.allegro.earth/?utm_source=openclaw-security-news</guid>
-      <category>Observability</category>
-    </item>
-    <item>
-      <title>VulnCheck - Ongoing OpenClaw CVE Advisories</title>
-      <link>https://www.vulncheck.com/advisories?utm_source=openclaw-security-news</link>
-      <guid isPermaLink="true">https://www.vulncheck.com/advisories?utm_source=openclaw-security-news</guid>
-      <category>Vendor Advisories</category>
     </item>
   </channel>
 </rss>

--- a/scripts/generate_feed.py
+++ b/scripts/generate_feed.py
@@ -8,6 +8,7 @@ date descending (most recently added first), and writes feed.xml.
 
 import csv
 import re
+import subprocess
 from datetime import datetime, timezone
 from email.utils import format_datetime
 from pathlib import Path
@@ -54,6 +55,30 @@ def parse_date_from_text(text: str):
             return datetime.strptime(raw, fmt).replace(tzinfo=timezone.utc)
         except ValueError:
             continue
+    return None
+
+
+def git_added_date(url: str):
+    """Return the date the URL first appeared in README.md, per git history.
+
+    Used as a pubDate fallback for evergreen links (search pages, trackers)
+    whose titles carry no date. Without a pubDate, RSS readers treat items
+    as brand-new on first fetch and float them above the real headlines.
+    Returns None if git history is unavailable (e.g. shallow clone).
+    """
+    try:
+        out = subprocess.run(
+            ["git", "log", "--reverse", "--format=%aI", "-S", url, "--", "README.md"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        first = out.stdout.strip().split("\n")[0].strip()
+        if first:
+            return datetime.fromisoformat(first).astimezone(timezone.utc)
+    except (OSError, ValueError, subprocess.SubprocessError):
+        pass
     return None
 
 
@@ -234,6 +259,9 @@ def build_rss(entries: list) -> str:
 def main():
     blocked = load_blocked_urls(REPO_ROOT / "never_add.csv")
     entries = parse_readme(REPO_ROOT / "README.md", blocked)
+    for entry in entries:
+        if not entry["pub_date"]:
+            entry["pub_date"] = git_added_date(entry["url"])
     sorted_entries = sort_entries(entries)
     xml_content = build_rss(sorted_entries)
 


### PR DESCRIPTION
## Summary
This PR adds a mechanism to populate missing publication dates for evergreen links (search pages, trackers, advisories) in the RSS feed by querying git history. This prevents RSS readers from treating these items as brand-new on each fetch and floating them above actual security news headlines.
